### PR TITLE
[support]: remove paths-ignore

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -8,8 +8,6 @@ on:
       - 'release/**'
     tags:
       - v**
-    paths-ignore:
-      - '**/README.md'
 
 env:
   IMAGE_NAME: ${{ github.event.repository.name }}


### PR DESCRIPTION
Свойство paths-ignore очень неоднозначное. Лучше пользователься белыми списками, а исключать с помощью `- '!**/*.md'` в `paths`